### PR TITLE
bug fix for wrong match way

### DIFF
--- a/redis-wireshark.lua
+++ b/redis-wireshark.lua
@@ -73,7 +73,7 @@ do -- scope
                     offset = offset + length + CRLF
 
                     -- get the string contained within this bulk message
-                    local line = matches()
+--                    local line = matches()
                     local length = bytes
                     child:add(f.value, buffer(offset, bytes))
                     offset = offset + length + CRLF


### PR DESCRIPTION
This commit fix the following problem
- you will get wrong length if there are some `\r\n` in the value, so use `bytes` instead of a matched `line` when you try to get a `value` from `buffer`
- you will get wrong body size if there are some `$` contained in the `value` so you should not use a while loop when you get a `*`. 